### PR TITLE
Check for removed entries

### DIFF
--- a/charts/polkadot-registrar-challenger/Chart.yaml
+++ b/charts/polkadot-registrar-challenger/Chart.yaml
@@ -1,5 +1,5 @@
 description: Polkadot Challenger
 name: polkadot-registrar-challenger
-version: v0.3.5
-appVersion: v0.3.5
+version: v0.3.6
+appVersion: v0.3.6
 apiVersion: v2

--- a/src/database.rs
+++ b/src/database.rs
@@ -90,8 +90,8 @@ impl Database {
                 }
             }
 
-            // If nothing was modified, return.
-            if !has_changed {
+            // If nothing was modified, return (detect removed entries).
+            if !has_changed && request.fields.len() == current.fields.len() {
                 return Ok(false);
             }
 


### PR DESCRIPTION
The state is not updated if an entry was only removed, rather than its value modified. I had a test which checks for both (removed and modified), but not a test case for _only removed_.