### PR TITLE
Avoid time-based assumptions about events

### DIFF
--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -241,15 +241,8 @@ pub mod tests {
             }
         }
         pub async fn send(&self, msg: ExternalMessage) {
-            use tokio::time::sleep;
-
-            {
-                let mut lock = self.messages.lock().await;
-                (*lock).push(msg);
-            }
-
-            // Give the adapter enough time to fetch and process messages.
-            sleep(Duration::from_secs(crate::tests::TEST_TIMEOUT)).await;
+            let mut lock = self.messages.lock().await;
+            (*lock).push(msg);
         }
     }
 

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -1,6 +1,6 @@
 use crate::database::{Database, EventCursor};
 use crate::primitives::{
-    ExpectedMessage, ExternalMessage, IdentityFieldValue, NotificationMessage, Timestamp,
+    ExpectedMessage, ExternalMessage, IdentityFieldValue, NotificationMessage,
 };
 use crate::{AdapterConfig, Result};
 use tokio::time::{interval, Duration};

--- a/src/connector.rs
+++ b/src/connector.rs
@@ -777,8 +777,6 @@ pub mod tests {
         /// A message received from the Watcher (mocked).
         pub async fn inject(&self, msg: WatcherMessage) {
             self.addr.send(msg).await.unwrap().unwrap();
-            // Give some time to process.
-            sleep(Duration::from_secs(crate::tests::TEST_TIMEOUT)).await;
         }
         pub async fn inserted_states(&self) -> Vec<JudgementState> {
             let mut states = self.inserted_states.write().await;

--- a/src/database.rs
+++ b/src/database.rs
@@ -833,8 +833,8 @@ impl Database {
     async fn insert_event<T: Into<Event>>(&self, event: T) -> Result<()> {
         let coll = self.db.collection(EVENT_COLLECTION);
 
-        let event: Event = event.into();
-        coll.insert_one(event.to_bson()?, None).await?;
+        coll.insert_one(<T as Into<Event>>::into(event).to_bson()?, None)
+            .await?;
 
         Ok(())
     }

--- a/src/database.rs
+++ b/src/database.rs
@@ -603,7 +603,7 @@ impl Database {
 
         Ok(events
             .into_iter()
-            .map(|wrapper| wrapper.event.event)
+            .map(|wrapper| wrapper.event.message)
             .collect())
     }
     pub async fn fetch_judgement_state(

--- a/src/database.rs
+++ b/src/database.rs
@@ -8,7 +8,7 @@ use crate::primitives::{
 use crate::Result;
 use bson::{doc, from_document, to_bson, to_document, Bson, Document};
 use futures::StreamExt;
-use mongodb::options::{FindOptions, UpdateOptions};
+use mongodb::options::UpdateOptions;
 use mongodb::{Client, Database as MongoDb};
 use rand::{thread_rng, Rng};
 use serde::Serialize;
@@ -35,6 +35,7 @@ impl<T: Serialize> ToBson for T {
     }
 }
 
+/// This
 pub struct EventCursor {
     timestamp: Timestamp,
     last_ids: HashSet<String>,
@@ -595,8 +596,8 @@ impl Database {
 
         event_tracker.last_ids = fetched_ids;
 
-        // Sort by timestamp, ascending.
-        events.sort_by(|a, b| a.event.timestamp.raw().cmp(&b.event.timestamp.raw()));
+        // Sort by id, ascending.
+        events.sort_by(|a, b| a.id.cmp(&b.id));
 
         Ok(events
             .into_iter()

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -358,7 +358,7 @@ impl From<u32> for MessageId {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub struct Timestamp(u64);
 
@@ -377,6 +377,13 @@ impl Timestamp {
     pub fn with_offset(offset: u64) -> Self {
         let now = Self::now();
         Timestamp(now.0 + offset)
+    }
+    pub fn max(self, other: Timestamp) -> Self {
+        if self.0 >= other.0 {
+            self
+        } else {
+            other
+        }
     }
     pub fn raw(&self) -> u64 {
         self.0

--- a/src/primitives.rs
+++ b/src/primitives.rs
@@ -404,14 +404,14 @@ impl From<String> for MessagePart {
 #[serde(rename_all = "snake_case")]
 pub struct Event {
     pub timestamp: Timestamp,
-    pub event: NotificationMessage,
+    pub message: NotificationMessage,
 }
 
 impl Event {
-    pub fn new(event: NotificationMessage) -> Self {
+    pub fn new(message: NotificationMessage) -> Self {
         Event {
             timestamp: Timestamp::now(),
-            event,
+            message,
         }
     }
 }

--- a/src/tests/api_judgement_state.rs
+++ b/src/tests/api_judgement_state.rs
@@ -7,7 +7,7 @@ use crate::primitives::{
     NotificationMessage, Timestamp,
 };
 use actix_http::StatusCode;
-use futures::{FutureExt, SinkExt, StreamExt};
+use futures::{FutureExt, StreamExt};
 
 #[actix::test]
 async fn current_judgement_state_single_identity() {

--- a/src/tests/api_judgement_state.rs
+++ b/src/tests/api_judgement_state.rs
@@ -845,7 +845,7 @@ async fn verify_full_identity() {
     let resp: JsonResult<ResponseAccountState> = stream_alice.next().await.into();
     // The completion timestamp is not that important, as long as it's `Some`.
     let completion_timestamp = match &resp {
-        JsonResult::Ok(r) => r.state.completion_timestamp.clone(),
+        JsonResult::Ok(r) => r.state.completion_timestamp,
         _ => panic!(),
     };
 

--- a/src/tests/api_judgement_state.rs
+++ b/src/tests/api_judgement_state.rs
@@ -20,10 +20,9 @@ async fn current_judgement_state_single_identity() {
     let alice = states[0].clone();
 
     // Subscribe to endpoint.
-    stream.send(IdentityContext::alice().to_ws()).await.unwrap();
+    let resp = subscribe_context(&mut stream, IdentityContext::alice()).await;
 
     // Check current state.
-    let resp: JsonResult<ResponseAccountState> = stream.next().await.into();
     assert_eq!(
         resp,
         JsonResult::Ok(ResponseAccountState::with_no_notifications(alice))
@@ -47,10 +46,9 @@ async fn current_judgement_state_multiple_inserts() {
     connector.inject(alice_judgement_request()).await;
 
     // Subscribe to endpoint.
-    stream.send(IdentityContext::alice().to_ws()).await.unwrap();
+    let resp = subscribe_context(&mut stream, IdentityContext::alice()).await;
 
     // Check current state.
-    let resp: JsonResult<ResponseAccountState> = stream.next().await.into();
     assert_eq!(
         resp,
         JsonResult::Ok(ResponseAccountState::with_no_notifications(alice))
@@ -73,19 +71,17 @@ async fn current_judgement_state_multiple_identities() {
     let bob = states[1].clone();
 
     // Subscribe to endpoint.
-    stream.send(IdentityContext::alice().to_ws()).await.unwrap();
+    let resp = subscribe_context(&mut stream, IdentityContext::alice()).await;
 
     // Check current state (Alice).
-    let resp: JsonResult<ResponseAccountState> = stream.next().await.into();
     assert_eq!(
         resp,
         JsonResult::Ok(ResponseAccountState::with_no_notifications(alice))
     );
 
-    stream.send(IdentityContext::bob().to_ws()).await.unwrap();
+    let resp = subscribe_context(&mut stream, IdentityContext::bob()).await;
 
     // Check current state (Bob).
-    let resp: JsonResult<ResponseAccountState> = stream.next().await.into();
     assert_eq!(
         resp,
         JsonResult::Ok(ResponseAccountState::with_no_notifications(bob))
@@ -107,10 +103,9 @@ async fn current_judgement_state_field_updated() {
     let alice = states[0].clone();
 
     // Subscribe to endpoint.
-    stream.send(IdentityContext::alice().to_ws()).await.unwrap();
+    let resp = subscribe_context(&mut stream, IdentityContext::alice()).await;
 
     // Check current state (Alice).
-    let resp: JsonResult<ResponseAccountState> = stream.next().await.into();
     assert_eq!(
         resp,
         JsonResult::Ok(ResponseAccountState::with_no_notifications(alice.clone()))
@@ -170,10 +165,9 @@ async fn current_judgement_state_single_entry_removed() {
     let alice = states[0].clone();
 
     // Subscribe to endpoint.
-    stream.send(IdentityContext::alice().to_ws()).await.unwrap();
+    let resp = subscribe_context(&mut stream, IdentityContext::alice()).await;
 
     // Check current state (Alice).
-    let resp: JsonResult<ResponseAccountState> = stream.next().await.into();
     assert_eq!(
         resp,
         JsonResult::Ok(ResponseAccountState::with_no_notifications(alice.clone()))
@@ -227,10 +221,9 @@ async fn verify_invalid_message_bad_challenge() {
     let bob = states[1].clone();
 
     // Subscribe to endpoint.
-    stream.send(IdentityContext::alice().to_ws()).await.unwrap();
+    let resp = subscribe_context(&mut stream, IdentityContext::alice()).await;
 
     // Check current state.
-    let resp: JsonResult<ResponseAccountState> = stream.next().await.into();
     assert_eq!(
         resp,
         JsonResult::Ok(ResponseAccountState::with_no_notifications(alice.clone()))
@@ -262,9 +255,8 @@ async fn verify_invalid_message_bad_challenge() {
     assert_eq!(resp, JsonResult::Ok(expected));
 
     // Other judgement states must be unaffected (Bob).
-    stream.send(IdentityContext::bob().to_ws()).await.unwrap();
+    let resp = subscribe_context(&mut stream, IdentityContext::bob()).await;
 
-    let resp: JsonResult<ResponseAccountState> = stream.next().await.into();
     assert_eq!(
         resp,
         JsonResult::Ok(ResponseAccountState::with_no_notifications(bob.clone()))
@@ -287,10 +279,9 @@ async fn verify_invalid_message_bad_origin() {
     let bob = states[1].clone();
 
     // Subscribe to endpoint.
-    stream.send(IdentityContext::alice().to_ws()).await.unwrap();
+    let resp = subscribe_context(&mut stream, IdentityContext::alice()).await;
 
     // Check current state.
-    let resp: JsonResult<ResponseAccountState> = stream.next().await.into();
     assert_eq!(
         resp,
         JsonResult::Ok(ResponseAccountState::with_no_notifications(alice.clone()))
@@ -313,9 +304,8 @@ async fn verify_invalid_message_bad_origin() {
     assert!(stream.next().now_or_never().is_none());
 
     // Other judgement states must be unaffected (Bob).
-    stream.send(IdentityContext::bob().to_ws()).await.unwrap();
+    let resp = subscribe_context(&mut stream, IdentityContext::bob()).await;
 
-    let resp: JsonResult<ResponseAccountState> = stream.next().await.into();
     assert_eq!(
         resp,
         JsonResult::Ok(ResponseAccountState::with_no_notifications(bob.clone()))
@@ -338,10 +328,9 @@ async fn verify_valid_message() {
     let bob = states[1].clone();
 
     // Subscribe to endpoint.
-    stream.send(IdentityContext::alice().to_ws()).await.unwrap();
+    let resp = subscribe_context(&mut stream, IdentityContext::alice()).await;
 
     // Check current state.
-    let resp: JsonResult<ResponseAccountState> = stream.next().await.into();
     assert_eq!(
         resp,
         JsonResult::Ok(ResponseAccountState::with_no_notifications(alice.clone()))
@@ -380,9 +369,8 @@ async fn verify_valid_message() {
     assert_eq!(resp, JsonResult::Ok(expected));
 
     // Other judgement states must be unaffected (Bob).
-    stream.send(IdentityContext::bob().to_ws()).await.unwrap();
+    let resp = subscribe_context(&mut stream, IdentityContext::bob()).await;
 
-    let resp: JsonResult<ResponseAccountState> = stream.next().await.into();
     assert_eq!(
         resp,
         JsonResult::Ok(ResponseAccountState::with_no_notifications(bob.clone()))
@@ -415,10 +403,9 @@ async fn verify_valid_message_duplicate_account_name() {
     let mut bob = states[1].clone();
 
     // Subscribe to endpoint.
-    stream.send(IdentityContext::alice().to_ws()).await.unwrap();
+    let resp = subscribe_context(&mut stream, IdentityContext::alice()).await;
 
     // Check current state.
-    let resp: JsonResult<ResponseAccountState> = stream.next().await.into();
     assert_eq!(
         resp,
         JsonResult::Ok(ResponseAccountState::with_no_notifications(alice.clone()))
@@ -457,11 +444,10 @@ async fn verify_valid_message_duplicate_account_name() {
     assert_eq!(resp, JsonResult::Ok(expected));
 
     // Other judgement states must be unaffected (Bob), but will receive a "failed attempt".
-    stream.send(IdentityContext::bob().to_ws()).await.unwrap();
+    let resp = subscribe_context(&mut stream, IdentityContext::bob()).await;
 
     *bob.get_field_mut(&F::ALICE_MATRIX()).failed_attempts_mut() = 1;
 
-    let resp: JsonResult<ResponseAccountState> = stream.next().await.into();
     assert_eq!(
         resp,
         JsonResult::Ok(ResponseAccountState::with_no_notifications(bob.clone()))
@@ -484,10 +470,9 @@ async fn verify_valid_message_awaiting_second_challenge() {
     let bob = states[1].clone();
 
     // Subscribe to endpoint.
-    stream.send(IdentityContext::alice().to_ws()).await.unwrap();
+    let resp = subscribe_context(&mut stream, IdentityContext::alice()).await;
 
     // Check current state.
-    let resp: JsonResult<ResponseAccountState> = stream.next().await.into();
     assert_eq!(
         resp,
         JsonResult::Ok(ResponseAccountState::with_no_notifications(alice.clone()))
@@ -575,9 +560,8 @@ async fn verify_valid_message_awaiting_second_challenge() {
     assert_eq!(resp, JsonResult::Ok(expected));
 
     // Other judgement state must be unaffected (Bob).
-    stream.send(IdentityContext::bob().to_ws()).await.unwrap();
+    let resp = subscribe_context(&mut stream, IdentityContext::bob()).await;
 
-    let resp: JsonResult<ResponseAccountState> = stream.next().await.into();
     assert_eq!(
         resp,
         JsonResult::Ok(ResponseAccountState::with_no_notifications(bob.clone()))
@@ -600,10 +584,9 @@ async fn verify_invalid_message_awaiting_second_challenge() {
     let bob = states[1].clone();
 
     // Subscribe to endpoint.
-    stream.send(IdentityContext::alice().to_ws()).await.unwrap();
+    let resp = subscribe_context(&mut stream, IdentityContext::alice()).await;
 
     // Check current state.
-    let resp: JsonResult<ResponseAccountState> = stream.next().await.into();
     assert_eq!(
         resp,
         JsonResult::Ok(ResponseAccountState::with_no_notifications(alice.clone()))
@@ -681,9 +664,8 @@ async fn verify_invalid_message_awaiting_second_challenge() {
     assert_eq!(resp, JsonResult::Ok(expected));
 
     // Other judgement state must be unaffected (Bob).
-    stream.send(IdentityContext::bob().to_ws()).await.unwrap();
+    let resp = subscribe_context(&mut stream, IdentityContext::bob()).await;
 
-    let resp: JsonResult<ResponseAccountState> = stream.next().await.into();
     assert_eq!(
         resp,
         JsonResult::Ok(ResponseAccountState::with_no_notifications(bob.clone()))
@@ -707,19 +689,12 @@ async fn verify_full_identity() {
     let bob = states[1].clone();
 
     // Subscribe to endpoint.
-    stream_alice
-        .send(IdentityContext::alice().to_ws())
-        .await
-        .unwrap();
-    stream_bob
-        .send(IdentityContext::bob().to_ws())
-        .await
-        .unwrap();
+    let resp_alice = subscribe_context(&mut stream_alice, IdentityContext::alice()).await;
+    let resp_bob = subscribe_context(&mut stream_bob, IdentityContext::bob()).await;
 
     // Check initial state
-    let resp: JsonResult<ResponseAccountState> = stream_alice.next().await.into();
     assert_eq!(
-        resp,
+        resp_alice,
         JsonResult::Ok(ResponseAccountState::with_no_notifications(alice.clone()))
     );
 
@@ -899,9 +874,8 @@ async fn verify_full_identity() {
     assert_eq!(resp, JsonResult::Ok(exp_resp));
 
     // Bob remains unchanged.
-    let resp: JsonResult<ResponseAccountState> = stream_bob.next().await.into();
     assert_eq!(
-        resp,
+        resp_bob,
         JsonResult::Ok(ResponseAccountState::with_no_notifications(bob.clone()))
     );
 

--- a/src/tests/live_mocker.rs
+++ b/src/tests/live_mocker.rs
@@ -62,7 +62,7 @@ async fn run_mocker() -> Result<()> {
     loop {
         let ty_msg: u32 = rng.gen_range(0..2);
         let ty_validity = rng.gen_range(0..1);
-        let reset = rng.gen_range(0..5);
+        let reset = rng.gen_range(0..9);
 
         if reset == 0 {
             warn!("Resetting Identity");
@@ -134,6 +134,6 @@ async fn run_mocker() -> Result<()> {
             })
             .await;
 
-        sleep(Duration::from_secs(2)).await;
+        sleep(Duration::from_secs(4)).await;
     }
 }

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -95,9 +95,6 @@ async fn new_env() -> (Database, ConnectorMocker, TestServer, MessageInjector) {
         run_session_notifier(t_db, actor).await;
     });
 
-    // Let tasks startup
-    sleep(Duration::from_secs(5)).await;
-
     // Setup connector mocker
     let connector = ConnectorMocker::new(db.clone());
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -27,12 +27,6 @@ mod process_admin_cmds;
 // Convenience type
 pub type F = IdentityFieldValue;
 
-// Given that many concurrent process are in play (async, websockets, channels,
-// etc) and not everything happens at the same time, we use a very conservative
-// timeout for certain operations when running tests, like when injecting
-// messages or waiting for events to happen.
-pub const TEST_TIMEOUT: u64 = 5;
-
 trait ToWsMessage {
     fn to_ws(&self) -> Message;
 }
@@ -98,9 +92,6 @@ async fn new_env() -> (Database, ConnectorMocker, TestServer, MessageInjector) {
 
     // Setup connector mocker
     let connector = ConnectorMocker::new(db.clone());
-
-    // Give some time to start up.
-    sleep(Duration::from_secs(TEST_TIMEOUT)).await;
 
     //(server, connector, injector)
     (db, connector, server, injector)

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,18 +1,21 @@
 use crate::adapters::tests::MessageInjector;
 use crate::adapters::AdapterListener;
-use crate::api::JsonResult;
+use crate::api::{JsonResult, ResponseAccountState};
 use crate::connector::{AccountType, JudgementRequest, WatcherMessage};
 use crate::database::Database;
 use crate::notifier::run_session_notifier;
-use crate::primitives::IdentityFieldValue;
+use crate::primitives::{IdentityFieldValue, IdentityContext};
 use crate::{api::tests::run_test_server, connector::tests::ConnectorMocker};
 use actix_http::ws::{Frame, ProtocolError};
 use actix_test::TestServer;
 use actix_web_actors::ws::Message;
+use actix_codec::{AsyncRead, AsyncWrite, Framed};
+use actix_http::ws::Codec;
 use rand::{thread_rng, Rng};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use tokio::time::{sleep, Duration};
+use futures::{FutureExt, SinkExt, StreamExt};
 
 mod api_judgement_state;
 mod background_tasks;
@@ -47,6 +50,18 @@ impl<T: DeserializeOwned> From<Option<Result<Frame, ProtocolError>>> for JsonRes
             _ => panic!(),
         }
     }
+}
+
+pub async fn subscribe_context(stream: &mut Framed<impl AsyncRead + AsyncWrite + std::marker::Unpin, Codec>, context: IdentityContext) -> JsonResult<ResponseAccountState> {
+    stream.send(context.to_ws()).await.unwrap();
+    let mut resp = stream.next().await.into();
+
+    while matches!(resp, JsonResult::Err(_)) {{
+        sleep(Duration::from_millis(500)).await;
+        resp = stream.next().await.into();
+    }}
+
+    resp
 }
 
 pub fn alice_judgement_request() -> WatcherMessage {

--- a/src/tests/process_admin_cmds.rs
+++ b/src/tests/process_admin_cmds.rs
@@ -227,7 +227,7 @@ async fn command_verify_all() {
 
     // The completion timestamp is not that important, as long as it's `Some`.
     let completion_timestamp = match &resp {
-        JsonResult::Ok(r) => r.state.completion_timestamp.clone(),
+        JsonResult::Ok(r) => r.state.completion_timestamp,
         _ => panic!(),
     };
 

--- a/src/tests/process_admin_cmds.rs
+++ b/src/tests/process_admin_cmds.rs
@@ -4,7 +4,7 @@ use crate::api::{JsonResult, ResponseAccountState};
 use crate::primitives::{
     IdentityContext, IdentityFieldValue, JudgementStateBlanked, NotificationMessage,
 };
-use futures::{FutureExt, SinkExt, StreamExt};
+use futures::{FutureExt, StreamExt};
 
 #[actix::test]
 async fn command_status() {
@@ -31,10 +31,9 @@ async fn command_verify_multiple_challenge_types() {
     let mut alice = states[0].clone();
 
     // Subscribe to endpoint.
-    stream.send(IdentityContext::alice().to_ws()).await.unwrap();
+    let resp = subscribe_context(&mut stream, IdentityContext::alice()).await;
 
     // Check current state.
-    let resp: JsonResult<ResponseAccountState> = stream.next().await.into();
     assert_eq!(
         resp,
         JsonResult::Ok(ResponseAccountState::with_no_notifications(alice.clone()))
@@ -150,10 +149,9 @@ async fn command_verify_unsupported_field() {
     let mut alice = states[0].clone();
 
     // Subscribe to endpoint.
-    stream.send(IdentityContext::alice().to_ws()).await.unwrap();
+    let resp = subscribe_context(&mut stream, IdentityContext::alice()).await;
 
     // Check current state.
-    let resp: JsonResult<ResponseAccountState> = stream.next().await.into();
     assert_eq!(
         resp,
         JsonResult::Ok(ResponseAccountState::with_no_notifications(alice.clone()))
@@ -204,10 +202,9 @@ async fn command_verify_all() {
     let mut alice = states[0].clone();
 
     // Subscribe to endpoint.
-    stream.send(IdentityContext::alice().to_ws()).await.unwrap();
+    let resp = subscribe_context(&mut stream, IdentityContext::alice()).await;
 
     // Check current state.
-    let resp: JsonResult<ResponseAccountState> = stream.next().await.into();
     assert_eq!(
         resp,
         JsonResult::Ok(ResponseAccountState::with_no_notifications(alice.clone()))
@@ -297,10 +294,9 @@ async fn command_verify_missing_field() {
     let alice = states[0].clone();
 
     // Subscribe to endpoint.
-    stream.send(IdentityContext::alice().to_ws()).await.unwrap();
+    let resp = subscribe_context(&mut stream, IdentityContext::alice()).await;
 
     // Check current state.
-    let resp: JsonResult<ResponseAccountState> = stream.next().await.into();
     assert_eq!(
         resp,
         JsonResult::Ok(ResponseAccountState::with_no_notifications(alice.clone()))


### PR DESCRIPTION
_(Do NOT merge yet, some more testing to do)_

In the current implementation, the event message handler uses a tick-based system to fetch events, given that the Rust mongodb driver does not support change-streams yet (notification system). What can happen is that some events get skipped if they occur too quickly, meaning within milliseconds (which is doesn't really happen in production). If it does happen then it's not exactly tragic, but this might cause some people having to reload the website. Problems mostly occurred when running unit tests, where I had to introduce some timeouts to replicate "real world behavior". I guess this is a general difficulty in async applications.

The new implementation caches Ids for a while, does not skip events no matter how quickly those are created and it avoids sending duplicates.